### PR TITLE
Ensure game sessions cannot be created if the user is in a game session

### DIFF
--- a/wavelength-api/Persistence/Repositories/IGameSessionRepository.cs
+++ b/wavelength-api/Persistence/Repositories/IGameSessionRepository.cs
@@ -5,7 +5,7 @@ namespace Persistence.Repositories;
 
 public interface IGameSessionRepository
 {
-    public Task<GameSessionDTO> Create(Guid ownerID);
+    public Task<GameSessionDTO?> Create(Guid ownerID);
 
     public Task<GameSessionDTO?> Get(Guid gameSessionID);
 
@@ -16,4 +16,6 @@ public interface IGameSessionRepository
     public Task<bool> End(Guid gameSessionID);
 
     public Task<bool> Start(Guid gameSessionID);
+
+    public Task<GameSessionDTO?> GetActiveSession(Guid userID);
 }


### PR DESCRIPTION
This pull request resolves #41 

## Short Description of Changes

- I added a repository method to get an active game session method for a user
- I ensured that users cannot create game sessions if they are actively a part of a game session

## Testing of These Changes

- Not tested