### PR TITLE
Jr 38 add copy icon

### DIFF
--- a/wavelength/src/assets/icons/CopyIcon.tsx
+++ b/wavelength/src/assets/icons/CopyIcon.tsx
@@ -1,7 +1,7 @@
 import { IconProps } from "./icon";
 
 // Imported from https://heroicons.com/
-const ArrowRightIcon: React.FC<IconProps> = ({ className = "w-6 h-6" }) => (
+const CopyIcon: React.FC<IconProps> = ({ className = "w-6 h-6" }) => (
     <svg 
     xmlns="http://www.w3.org/2000/svg" 
     fill="none" 
@@ -19,4 +19,4 @@ const ArrowRightIcon: React.FC<IconProps> = ({ className = "w-6 h-6" }) => (
   
 );
 
-export default ArrowRightIcon;
+export default CopyIcon;

--- a/wavelength/src/components/navbar/NavBarButton.tsx
+++ b/wavelength/src/components/navbar/NavBarButton.tsx
@@ -1,5 +1,5 @@
 import { cn } from "../../utils/utils";
-import CopyTextIcon from "../../assets/icons/CopyTextIcon";
+import CopyTextIcon from "../../assets/icons/CopyIcon";
 
 
 type NavBarProps = {


### PR DESCRIPTION
This pull request resolves #38 

Add copy icon to the game code so users know that the code can be copied just from looking at it. 
As I was editng the code based on comments from the last PR, I accidently closed the request. This pr is the same branch, but with the edits made