### PR TITLE
Register page now works as long as proper password is provided

### DIFF
--- a/wavelength/src/api/api.ts
+++ b/wavelength/src/api/api.ts
@@ -51,7 +51,11 @@ const Account = {
       { email, password },
       { validateStatus: null }
     ),
-  register: (user: User) => requests.post<User>("/account/register", user),
+  register: (username: string, email: string, password: string, avatarId: string) => 
+    requests.post<User>(
+      "/account/register",
+       {username, email, password, avatarId},
+    ),
   getCurrentUser: () => requests.get<User>("/account"),
 };
 

--- a/wavelength/src/pages/RegisterPage.tsx
+++ b/wavelength/src/pages/RegisterPage.tsx
@@ -1,13 +1,11 @@
 import { useNavigate } from "react-router";
 import { WavelengthPath } from "../routing/Routes";
-import User from "../models/User";
 import React, { ChangeEvent, useState } from 'react';
-// import {account} from "../api/api"
 import { useStore } from "../stores/store";
 import { useStoreValue } from "../stores/storeValue";
+import { observer } from "mobx-react-lite";
 
-
-const RegisterPage: React.FC = () => {
+const RegisterPage: React.FC = observer(() => {
   const navigate = useNavigate();
   const [email, setEmail] = useState("")
   const [username, setUsername] = useState("")
@@ -36,22 +34,27 @@ const RegisterPage: React.FC = () => {
     setConfirm(event.target.value);
   }
 
-  function handleRegisterClick(){
-    //Still need to connect to backend and actually register the user
-    // const user = await register();
-    // if(user){
-      // navigate(WavelengthPath.LANDING);
-    // }
-
-    navigate(WavelengthPath.LANDING);
+  const handleRegisterSubmit = async () => {
+    const user = await register(username, email, password, "8bae381d-ba6a-4522-8b4d-ab57ea0459bd");
+    if(user){
+      navigate(WavelengthPath.LANDING);
+    }
   }
 
 
   return(
     <div className="h-screen flex justify-center self-center space-y-1/2">
-      <form className="grid grid-rows-4 gap-y-6 h-1/2 w-1/3 my-auto" onClick={handleRegisterClick}>
+      <form className="grid grid-rows-4 gap-y-6 h-1/2 w-1/3 my-auto" 
+        onSubmit={(e) => {
+          // Prevent page refresh from submit
+          e.preventDefault();
+          handleRegisterSubmit();
+        }}
+        autoComplete="on"
+        >
 
         <input //Enter Email
+        type="email"
         className="bg-theme-blue border-2 border-target-2 text-center w-full h-10 p-2 rounded-lg placeholder-white text-white" 
         placeholder="EMAIL" 
         onChange={handleEmailChange}>
@@ -64,6 +67,7 @@ const RegisterPage: React.FC = () => {
         </input>
 
         <input //Enter Password
+        type="password"
         className="bg-theme-blue border-2 border-target-3 text-center w-full h-10 p-2 rounded-lg placeholder-white text-white" 
         placeholder="PASSWORD" 
         min={8} 
@@ -71,6 +75,7 @@ const RegisterPage: React.FC = () => {
         </input>
 
         <input //Confirm Password
+        type="password"
         className="bg-theme-blue border-2 border-target-3 text-center w-full h-10 p-2 rounded-lg placeholder-white text-white" 
         placeholder="CONFIRM PASSWORD" 
         min={8} 
@@ -90,6 +95,6 @@ const RegisterPage: React.FC = () => {
       </form>
     </div>
   );
-};
+});
 
 export default RegisterPage;

--- a/wavelength/src/stores/userStore.ts
+++ b/wavelength/src/stores/userStore.ts
@@ -57,9 +57,9 @@ export default class UserStore {
     });
   };
 
-  register = async (newUser: User): Promise<User | undefined> => {
+  register = async (username: string, email: string, password: string, avatarId: string): Promise<User | undefined> => {
     return this.userStoreValue.handleAPICall(async () => {
-      const user = await api.Account.register(newUser);
+      const user = await api.Account.register(username, email, password, avatarId);
 
       if (user.token) {
         this.userStoreValue.setValue(user);


### PR DESCRIPTION
This pull request resolves #77 

## Short Description of Changes

The register page now actually register users, and sends them to the proper landing page when they do so. The register still needs two fixes, but I wanted to get teh functinoality out there first. 1) The avatarID is currently a random string, that doesn't correlate to any of the avatars. 2) If a password doesn't follow the proper rules, an error takes over the screen. 

## Additional Work Done
Changed the API calls to collect data needed to properly register a user. 
